### PR TITLE
Make auction photos optional

### DIFF
--- a/src/app/art/components/car-register/car-register.component.html
+++ b/src/app/art/components/car-register/car-register.component.html
@@ -244,7 +244,7 @@
       </div>
 
       <div class="col-span-2">
-        <p class="text-xl font-bold">Subir fotos del auto <span class="font-bold text-red-500 inline-block">*</span></p>
+        <p class="text-xl font-bold">Subir fotos del auto</p>
         <p class="mb-2 text-sm">Se recomienda subir fotos con orientación horizontal</p>
         <div #uppyDashboardImages></div>
 
@@ -284,7 +284,7 @@
           @if (isButtonSubmitDisabled()) {
           <shared-spinner></shared-spinner>
           } @else {
-          Enviar solicitud a revisión
+          Empezar mi registro
           }
         </button>
       </div>
@@ -298,5 +298,4 @@
 
   }
   }
-
 </div>

--- a/src/app/art/components/car-register/car-register.component.ts
+++ b/src/app/art/components/car-register/car-register.component.ts
@@ -86,7 +86,7 @@ export class CarRegisterComponent {
         restrictions: {
           maxFileSize: 20000000,
           // maxNumberOfFiles: 20,
-          minNumberOfFiles: 1,
+          minNumberOfFiles: 0,
           allowedFileTypes: ['image/*'],
         },
       }).use(Dashboard,
@@ -143,7 +143,7 @@ export class CarRegisterComponent {
         restrictions: {
           maxFileSize: 500000000,
           // maxNumberOfFiles: 20,
-          minNumberOfFiles: 1,
+          minNumberOfFiles: 0,
           allowedFileTypes: ['video/*'],
         },
       }).use(Dashboard,
@@ -270,7 +270,7 @@ export class CarRegisterComponent {
       otherTransmission: [null],
       engine: ['', Validators.required],
       howDidYouHearAboutUs: ['', Validators.required],
-      photos: [[], Validators.required],
+      photos: [[]],
       videos: [[]],
       acceptTerms: ['', Validators.required],
     });


### PR DESCRIPTION
## Summary
- start registration rather than submitting for review
- remove required validation on auction photos and relax file upload

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden due to lack of internet)*

------
https://chatgpt.com/codex/tasks/task_b_686e98a104088320a695617c9450cec6