### PR TITLE
Update car history placeholder

### DIFF
--- a/src/app/dashboard/components/auction-car-exterior-details/auction-car-exterior-details.component.html
+++ b/src/app/dashboard/components/auction-car-exterior-details/auction-car-exterior-details.component.html
@@ -150,9 +150,9 @@
 
   <!-- Historia del auto textarea -->
   <div class="col-span-2">
-    <label for="carHistory" class="block mb-1 text-sm">Historia del auto <span
+    <label for="carHistory" class="block mb-1 text-sm">Cuéntanos del exterior del auto <span
         class="font-bold text-red-500 inline-block">*</span></label>
-    <textarea id="carHistory" formControlName="carHistory" rows="6" sharedInput sharedAutoResizeTextarea></textarea>
+    <textarea id="carHistory" formControlName="carHistory" rows="6" placeholder="Ejemplo: Lo compré hace 5 años luego de un choque, reparé la pintura y cambié los rines. Describe experiencias, modificaciones y cualquier detalle relevante del exterior." sharedInput sharedAutoResizeTextarea></textarea>
     @if (hasError('carHistory')) {
     <shared-input-error [message]="getError('carHistory')"></shared-input-error>
     }

--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
@@ -141,9 +141,9 @@
 
   <!-- Historia del auto textarea -->
   <div class="col-span-2">
-    <label for="carHistory" class="block mb-1 text-sm">Historia del auto <span
+    <label for="carHistory" class="block mb-1 text-sm">Cuéntanos del exterior del auto <span
         class="font-bold text-red-500 inline-block">*</span></label>
-    <textarea id="carHistory" formControlName="carHistory" rows="6" sharedInput sharedAutoResizeTextarea></textarea>
+    <textarea id="carHistory" formControlName="carHistory" rows="6" placeholder="Ejemplo: Lo compré hace 5 años luego de un choque, reparé la pintura y cambié los rines. Describe experiencias, modificaciones y cualquier detalle relevante del exterior." sharedInput sharedAutoResizeTextarea></textarea>
     @if (hasError('carHistory')) {
     <shared-input-error [message]="getError('carHistory')"></shared-input-error>
     }


### PR DESCRIPTION
## Summary
- update label/placeholder for car history question on car registration
- same update for auction car exterior details

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ea4c1c0e08320972afb53cce69bd2