### PR TITLE
Update car history labels

### DIFF
--- a/src/app/dashboard/components/auction-car-exterior-details/auction-car-exterior-details.component.html
+++ b/src/app/dashboard/components/auction-car-exterior-details/auction-car-exterior-details.component.html
@@ -148,11 +148,13 @@
     }
   </div>
 
-  <!-- Historia del auto textarea -->
+  <!-- Cuéntanos del exterior del auto textarea -->
   <div class="col-span-2">
-    <label for="carHistory" class="block mb-1 text-sm">Historia del auto <span
+    <label for="carHistory" class="block mb-1 text-sm">Cuéntanos del exterior del auto <span
         class="font-bold text-red-500 inline-block">*</span></label>
-    <textarea id="carHistory" formControlName="carHistory" rows="6" sharedInput sharedAutoResizeTextarea></textarea>
+    <textarea id="carHistory" formControlName="carHistory" rows="6"
+      placeholder="Yo lo compré hace 5 años, nunca ha sido chocado, bla bla, qué experiencias han tenido con el, modificaciones, háblanos del exterior, pintura, detalles ..."
+      sharedInput sharedAutoResizeTextarea></textarea>
     @if (hasError('carHistory')) {
     <shared-input-error [message]="getError('carHistory')"></shared-input-error>
     }

--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
@@ -139,11 +139,13 @@
     }
   </div>
 
-  <!-- Historia del auto textarea -->
+  <!-- Cuéntanos del exterior del auto textarea -->
   <div class="col-span-2">
-    <label for="carHistory" class="block mb-1 text-sm">Historia del auto <span
+    <label for="carHistory" class="block mb-1 text-sm">Cuéntanos del exterior del auto <span
         class="font-bold text-red-500 inline-block">*</span></label>
-    <textarea id="carHistory" formControlName="carHistory" rows="6" sharedInput sharedAutoResizeTextarea></textarea>
+    <textarea id="carHistory" formControlName="carHistory" rows="6"
+      placeholder="Yo lo compré hace 5 años, nunca ha sido chocado, bla bla, qué experiencias han tenido con el, modificaciones, háblanos del exterior, pintura, detalles ..."
+      sharedInput sharedAutoResizeTextarea></textarea>
     @if (hasError('carHistory')) {
     <shared-input-error [message]="getError('carHistory')"></shared-input-error>
     }


### PR DESCRIPTION
## Summary
- tweak car history label text on vehicle registration form
- update same label in dashboard car exterior details

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ea66252f483208e223c90053b7d15