### PR TITLE
Add default exterior media for testing

### DIFF
--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.ts
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.ts
@@ -284,14 +284,29 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
         ];
 
         if (this.user && emails.includes(this.user.attributes.email)) {
-          //Sobreescribir con valores de prueba
+          // Sobreescribir con valores de prueba
           kmInput = kmInput || 123456;
           brand = brand || 'Toyota';
           year = year || 2020;
           carModel = carModel || 'Corolla';
           invoiceType = invoiceType || 'invoice';
           invoiceDetails = invoiceDetails || 'Paid in cash';
-          exteriorVideos = exteriorVideos || [];
+
+          exteriorPhotos =
+            exteriorPhotos && exteriorPhotos.length > 0
+              ? exteriorPhotos
+              : [
+                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/a135dd45-6c21-4dcd-b6b7-2b6619696500/public',
+                ];
+          exteriorVideos =
+            exteriorVideos && exteriorVideos.length > 0
+              ? exteriorVideos
+              : [
+                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/8e340451-9379-474c-85e4-2b0d2c0c3a00/public',
+                ];
+
+          this.exteriorPhotos.clearValidators();
+          this.exteriorPhotos.updateValueAndValidity();
         }
 
         this.exteriorOfTheCarForm.patchValue({


### PR DESCRIPTION
## Summary
- add sample exterior photos and videos when test users are detected
- disable exterior photo validation for these users to allow progression without uploads

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eac58490c8320879e18d3262c8370