### PR TITLE
Add car history field to exterior form

### DIFF
--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
@@ -70,6 +70,16 @@
     }
   </div>
 
+  <!-- Car history textarea -->
+  <div class="col-span-2">
+    <label for="carHistory" class="block mb-1 text-sm">Cuéntanos del exterior del auto <span class="font-bold text-red-500 inline-block">*</span></label>
+    <textarea id="carHistory" formControlName="carHistory" rows="6" placeholder="Explica detalles de el exterior, pintura, etc. Aquí un texto informativo para invitar a que se explayen con todo del exterior." sharedInput
+      sharedAutoResizeTextarea></textarea>
+    @if (hasError('carHistory')) {
+    <shared-input-error [message]="getError('carHistory')"></shared-input-error>
+    }
+  </div>
+
 
   <!-- Fotos del exterior del auto -->
   <div class="col-span-2">

--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.ts
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.ts
@@ -182,6 +182,7 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
       carModel: [{ value: '', disabled: true }, [Validators.required]],
       invoiceType: ['', [Validators.required]],
       invoiceDetails: ['', [Validators.required]],
+      carHistory: ['', [Validators.required]],
       exteriorPhotos: [[], [Validators.required]],
       exteriorVideos: [[]],
       originalAuctionCarId: [this.originalAuctionCarId(), [Validators.required]],
@@ -237,11 +238,6 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
       return;
     }
 
-    this.kmInputControl.enable();
-    this.brandControl.enable();
-    this.yearControl.enable();
-    this.carModelControl.enable();
-
     this.#completeCarRegistrationService.saveGeneralDetailsAndExteriorOfTheCar$(this.exteriorOfTheCarForm)
       .subscribe({
         next: () => {
@@ -251,10 +247,6 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
           window.scrollTo(0, 0);
         },
         error: (error) => {
-          this.kmInputControl.disable();
-          this.brandControl.disable();
-          this.yearControl.disable();
-          this.carModelControl.disable();
           console.error(error);
         },
       }).add(() => {
@@ -272,6 +264,7 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
           carModel,
           invoiceType,
           invoiceDetails,
+          carHistory,
           exteriorPhotos,
           exteriorVideos,
         } = response;
@@ -291,6 +284,7 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
           carModel = carModel || 'Corolla';
           invoiceType = invoiceType || 'invoice';
           invoiceDetails = invoiceDetails || 'Paid in cash';
+          carHistory = carHistory || 'Historia del auto';
 
           exteriorPhotos =
             exteriorPhotos && exteriorPhotos.length > 0
@@ -316,6 +310,7 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
           carModel,
           invoiceType,
           invoiceDetails,
+          carHistory,
           exteriorPhotos,
           exteriorVideos,
         });

--- a/src/app/register-car/interfaces/general-details.interface.ts
+++ b/src/app/register-car/interfaces/general-details.interface.ts
@@ -5,6 +5,7 @@ export interface GeneralDetails {
   kmInput: number;
   invoiceType: string;
   invoiceDetails: string;
+  carHistory: string;
   exteriorPhotos: string[];
   exteriorVideos: string[];
 }


### PR DESCRIPTION
## Summary
- add `carHistory` to interface and form
- display textarea for exterior history with placeholder
- stop enabling general info controls before submit

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eae6bc5508320a2816fc997c57278