### PR TITLE
Update interior step fields

### DIFF
--- a/src/app/auctions/interfaces/auction-details.ts
+++ b/src/app/auctions/interfaces/auction-details.ts
@@ -172,14 +172,11 @@ export interface AuctionDetailsInteriorDetails {
   _id: string;
   originalAuctionCarId: string;
   __v: number;
-  accessoriesFunctioning: boolean;
-  comments: string;
   interiorColor: string;
-  interiorCondition: string;
-  interiorModifications: boolean;
+  material: string;
+  interiorDetails: string;
   interiorPhotos: string[];
   interiorVideos: any[];
-  material: string;
 }
 
 export interface AuctionDetailsMechanicsDetails {

--- a/src/app/dashboard/components/auction-car-interior-details/auction-car-interior-details.component.html
+++ b/src/app/dashboard/components/auction-car-interior-details/auction-car-interior-details.component.html
@@ -46,56 +46,13 @@
     }
   </div>
 
-  <!-- Condiciones del interior select -->
+  <!-- Cúentanos cualquier detalle importante sobre el interior -->
   <div class="col-span-2">
-    <label for="interiorCondition" class="block mb-1 text-sm">Condiciones del interior <span
+    <label for="interiorDetails" class="block mb-1 text-sm">Cúentanos cualquier detalle importante sobre el interior <span
         class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="interiorCondition" formControlName="interiorCondition" sharedInput>
-      <!-- <option value disabled selected>Condiciones del interior</option> -->
-      <option value="excellent">Excelente</option>
-      <option value="good">Buena</option>
-      <option value="regular">Regular</option>
-      <option value="bad">Mala</option>
-    </select>
-    @if (hasError('interiorCondition')) {
-    <shared-input-error [message]="getError('interiorCondition')"></shared-input-error>
-    }
-  </div>
-
-  <!-- ¿Ha tenido modificaciones en el interior? select -->
-  <div class="col-span-2">
-    <label for="interiorModifications" class="block mb-1 text-sm">¿Ha tenido modificaciones en el
-      interior? <span class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="interiorModifications" formControlName="interiorModifications" sharedInput>
-      <!-- <option value disabled selected>¿Ha tenido modificaciones en el interior?</option> -->
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-    @if (hasError('interiorModifications')) {
-    <shared-input-error [message]="getError('interiorModifications')"></shared-input-error>
-    }
-  </div>
-
-  <!-- ¿Los accesorios y electrónicos funcionan? input-->
-  <div class="col-span-2">
-    <label for="accessoriesFunctioning" class="block mb-1 text-sm">¿Los accesorios y electrónicos
-      funcionan? <span class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="accessoriesFunctioning" formControlName="accessoriesFunctioning" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-    @if (hasError('accessoriesFunctioning')) {
-    <shared-input-error [message]="getError('accessoriesFunctioning')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Comentarios sobre detalles textarea -->
-  <div class="col-span-2">
-    <label for="comments" class="block mb-1 text-sm">Comentarios sobre detalles <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <textarea id="comments" formControlName="comments" rows="6" sharedInput sharedAutoResizeTextarea></textarea>
-    @if (hasError('comments')) {
-    <shared-input-error [message]="getError('comments')"></shared-input-error>
+    <textarea id="interiorDetails" formControlName="interiorDetails" rows="6" sharedInput sharedAutoResizeTextarea></textarea>
+    @if (hasError('interiorDetails')) {
+    <shared-input-error [message]="getError('interiorDetails')"></shared-input-error>
     }
   </div>
 

--- a/src/app/dashboard/components/auction-car-interior-details/auction-car-interior-details.component.ts
+++ b/src/app/dashboard/components/auction-car-interior-details/auction-car-interior-details.component.ts
@@ -45,10 +45,7 @@ export class AuctionCarInteriorDetailsComponent {
     this.interiorOfTheCarForm = this.#formBuilder.group({
       interiorColor: [{ value: '' }, [Validators.required]],
       material: ['', [Validators.required]],
-      interiorCondition: ['', [Validators.required]],
-      interiorModifications: ['', [Validators.required]],
-      accessoriesFunctioning: ['', [Validators.required]],
-      comments: ['', [Validators.required]],
+      interiorDetails: ['', [Validators.required]],
       interiorPhotos: [[], [Validators.required]],
       interiorVideos: [[]],
       originalAuctionCarId: ['', [Validators.required]],
@@ -65,10 +62,7 @@ export class AuctionCarInteriorDetailsComponent {
       this.interiorOfTheCarForm.patchValue({
         interiorColor: interiorDetails.interiorColor,
         material: interiorDetails.material,
-        interiorCondition: interiorDetails.interiorCondition,
-        interiorModifications: interiorDetails.interiorModifications,
-        accessoriesFunctioning: interiorDetails.accessoriesFunctioning,
-        comments: interiorDetails.comments,
+        interiorDetails: interiorDetails.interiorDetails,
         interiorPhotos: interiorDetails.interiorPhotos,
         interiorVideos: interiorDetails.interiorVideos,
         originalAuctionCarId: this.auctionCarId(),

--- a/src/app/dashboard/interfaces/wizard-data.ts
+++ b/src/app/dashboard/interfaces/wizard-data.ts
@@ -66,14 +66,11 @@ export interface WizardDataInteriorDetails {
   _id: string;
   originalAuctionCarId: string;
   __v: number;
-  accessoriesFunctioning: boolean;
-  comments: string;
   interiorColor: string;
-  interiorCondition: string;
-  interiorModifications: boolean;
+  material: string;
+  interiorDetails: string;
   interiorPhotos: string[];
   interiorVideos: any[];
-  material: string;
 }
 
 export interface WizardDataMechanicsDetails {

--- a/src/app/last-chance/interfaces/last-chance-auction-vehicle-detail.ts
+++ b/src/app/last-chance/interfaces/last-chance-auction-vehicle-detail.ts
@@ -161,14 +161,11 @@ export interface LastChanceAuctionVehicleDetailInteriorDetails {
   _id: string;
   originalAuctionCarId: string;
   __v: number;
-  accessoriesFunctioning: boolean;
-  comments: string;
   interiorColor: string;
-  interiorCondition: string;
-  interiorModifications: boolean;
+  material: string;
+  interiorDetails: string;
   interiorPhotos: string[];
   interiorVideos: any[];
-  material: string;
 }
 
 export interface LastChanceAuctionVehicleDetailMechanicsDetails {

--- a/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.html
+++ b/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.html
@@ -25,58 +25,15 @@
     }
   </div>
 
-  <!-- Condiciones del interior select -->
+  <!-- Cúentanos cualquier detalle importante sobre el interior -->
   <div class="col-span-2">
-    <label for="interiorCondition" class="block mb-1 text-sm">Condiciones del interior <span
+    <label for="interiorDetails" class="block mb-1 text-sm">Cúentanos cualquier detalle importante sobre el interior <span
         class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="interiorCondition" formControlName="interiorCondition" sharedInput>
-      <!-- <option value disabled selected>Condiciones del interior</option> -->
-      <option value="excellent">Excelente</option>
-      <option value="good">Buena</option>
-      <option value="regular">Regular</option>
-      <option value="bad">Mala</option>
-    </select>
-    @if (hasError('interiorCondition')) {
-    <shared-input-error [message]="getError('interiorCondition')"></shared-input-error>
-    }
-  </div>
-
-  <!-- ¿Ha tenido modificaciones en el interior? select -->
-  <div class="col-span-2">
-    <label for="interiorModifications" class="block mb-1 text-sm">¿Ha tenido modificaciones en el
-      interior? <span class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="interiorModifications" formControlName="interiorModifications" sharedInput>
-      <!-- <option value disabled selected>¿Ha tenido modificaciones en el interior?</option> -->
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-    @if (hasError('interiorModifications')) {
-    <shared-input-error [message]="getError('interiorModifications')"></shared-input-error>
-    }
-  </div>
-
-  <!-- ¿Los accesorios y electrónicos funcionan? input-->
-  <div class="col-span-2">
-    <label for="accessoriesFunctioning" class="block mb-1 text-sm">¿Los accesorios y electrónicos
-      funcionan? <span class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="accessoriesFunctioning" formControlName="accessoriesFunctioning" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-    @if (hasError('accessoriesFunctioning')) {
-    <shared-input-error [message]="getError('accessoriesFunctioning')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Comentarios sobre detalles textarea -->
-  <div class="col-span-2">
-    <label for="comments" class="block mb-1 text-sm">Comentarios sobre detalles <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <textarea id="comments" formControlName="comments" rows="6"
+    <textarea id="interiorDetails" formControlName="interiorDetails" rows="6"
       placeholder="El interior está en perfecto estado, cuenta con asientos de cuero en excelente condición, sin rasgaduras ni daños visibles. El tablero y la consola se mantienen originales y funcionan correctamente, al igual que todos los accesorios y electrónicos del vehículo."
       sharedInput sharedAutoResizeTextarea></textarea>
-    @if (hasError('comments')) {
-    <shared-input-error [message]="getError('comments')"></shared-input-error>
+    @if (hasError('interiorDetails')) {
+    <shared-input-error [message]="getError('interiorDetails')"></shared-input-error>
     }
   </div>
 

--- a/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
+++ b/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
@@ -175,10 +175,7 @@ export class InteriorOfTheCarComponent {
     this.interiorOfTheCarForm = this.#fb.group({
       interiorColor: [{ value: '', disabled: true }, [Validators.required]],
       material: ['', [Validators.required]],
-      interiorCondition: ['', [Validators.required]],
-      interiorModifications: ['', [Validators.required]],
-      accessoriesFunctioning: ['', [Validators.required]],
-      comments: ['', [Validators.required]],
+      interiorDetails: ['', [Validators.required]],
       interiorPhotos: [[], [Validators.required]],
       interiorVideos: [[]],
       originalAuctionCarId: [this.originalAuctionCarId, [Validators.required]],
@@ -245,10 +242,7 @@ export class InteriorOfTheCarComponent {
         let {
           interiorColor,
           material,
-          interiorCondition,
-          interiorModifications,
-          accessoriesFunctioning,
-          comments,
+          interiorDetails,
           interiorPhotos,
           interiorVideos,
         } = interiorOfTheCar;
@@ -264,10 +258,7 @@ export class InteriorOfTheCarComponent {
           //Sobreescribir con valores de prueba
           interiorColor = interiorColor || 'Black';
           material = material || 'Leather';
-          interiorCondition = interiorCondition || 'excellent';
-          interiorModifications = interiorModifications || false;
-          accessoriesFunctioning = accessoriesFunctioning || true;
-          comments = comments || 'No comments';
+          interiorDetails = interiorDetails || 'No comments';
           // interiorPhotos = (interiorPhotos && interiorPhotos.length > 0) ? interiorPhotos : ['https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/79c2c836-05b7-4063-de6f-1a8e105eaa00/public', 'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/27c09383-2145-475d-4992-7b7ecc191200/public'];
           interiorVideos = interiorVideos || [];
         }
@@ -275,10 +266,7 @@ export class InteriorOfTheCarComponent {
         this.interiorOfTheCarForm.patchValue({
           interiorColor,
           material,
-          interiorCondition,
-          interiorModifications,
-          accessoriesFunctioning,
-          comments,
+          interiorDetails,
           interiorPhotos,
           interiorVideos,
         });

--- a/src/app/register-car/interfaces/interior-of-the-car.interface.ts
+++ b/src/app/register-car/interfaces/interior-of-the-car.interface.ts
@@ -1,10 +1,8 @@
 export interface InteriorOfTheCar {
   interiorColor: string;
   material: string;
-  interiorCondition: string;
-  interiorModifications: boolean;
-  accessoriesFunctioning: boolean;
-  comments: string;
+  interiorDetails: string;
   interiorPhotos: string[];
   interiorVideos: string[];
+  originalAuctionCarId: string;
 }


### PR DESCRIPTION
## Summary
- remove unused interior fields from interior form step
- rename interior comments input to interior details
- adjust interfaces and dashboard to match new interior details fields

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eb2541f548320be9e079d1d6d0f42