### PR TITLE
Update mechanics fields to match new API

### DIFF
--- a/src/app/dashboard/services/update-auction-car-details-data.service.ts
+++ b/src/app/dashboard/services/update-auction-car-details-data.service.ts
@@ -37,7 +37,25 @@ export class UpdateAuctionCarDetailsDataService {
 
   // /update-mechanics-details/:auctionCarId
   updateMechanicsDetails$(auctionCarId: string, form: FormGroup): Observable<any> {
-    const trimmedMechanicsDetails = this.#appService.trimObjectValues(form.value);
+    const {
+      tireBrand,
+      tireSize,
+      spareTire,
+      comments,
+      mechanicsPhotos,
+      mechanicsVideos,
+      originalAuctionCarId,
+    } = form.value;
+
+    const trimmedMechanicsDetails = this.#appService.trimObjectValues({
+      tireBrand,
+      tireSize,
+      spareTire,
+      comments,
+      mechanicsPhotos,
+      mechanicsVideos,
+      originalAuctionCarId,
+    });
 
     return this.#http.put(`${this.#baseUrl}/auctions-cars/update-mechanics-details/${auctionCarId}`, trimmedMechanicsDetails);
   }

--- a/src/app/register-car/components/mechanics/mechanics.component.html
+++ b/src/app/register-car/components/mechanics/mechanics.component.html
@@ -3,20 +3,6 @@
 <h2 class="text-xl font-bold mb-5">Llantas y rines</h2>
 
 <form [formGroup]="mechanicsForm" (ngSubmit)="mechanicsFormSubmit()" class="grid grid-cols-2 items-end gap-5">
-  <!-- Rines originales select -->
-  <div>
-    <label for="originalRims" class="block mb-1 text-sm">¿Rines originales? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="originalRims" formControlName="originalRims" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('originalRims')) {
-    <shared-input-error [message]="getError('originalRims')"></shared-input-error>
-    }
-  </div>
-
   <!-- Marca de llantas -->
   <div>
     <label for="tireBrand" class="block mb-1 text-sm">Marca de llantas</label>
@@ -35,44 +21,6 @@
     }
   </div>
 
-  <!-- tireDate input -->
-  <div>
-    <label for="tireDate" class="block mb-1 text-sm">Fecha de llantas</label>
-    <input id="tireDate" formControlName="tireDate" type="date" sharedInput>
-    @if (hasError('tireDate')) {
-    <shared-input-error [message]="getError('tireDate')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Condición de llantas -->
-  <div>
-    <label for="tireCondition" class="block mb-1 text-sm">Condición de llantas <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="tireCondition" formControlName="tireCondition" sharedInput>
-      <option value="Excelente">Excelente</option>
-      <option value="Buena">Buena</option>
-      <option value="Regular">Regular</option>
-      <option value="Mala">Mala</option>
-    </select>
-    @if (hasError('tireCondition')) {
-    <shared-input-error [message]="getError('tireCondition')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Llantas o rines extras select -->
-  <div>
-    <label for="extraTiresOrRims" class="block mb-1 text-sm">¿Llantas o rines extras? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="extraTiresOrRims" formControlName="extraTiresOrRims" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('extraTiresOrRims')) {
-    <shared-input-error [message]="getError('extraTiresOrRims')"></shared-input-error>
-    }
-  </div>
-
   <!-- Llanta de refacción select -->
   <div>
     <label for="spareTire" class="block mb-1 text-sm">¿Llanta de refacción? <span
@@ -84,104 +32,6 @@
 
     @if (hasError('spareTire')) {
     <shared-input-error [message]="getError('spareTire')"></shared-input-error>
-    }
-  </div>
-
-  <div class="col-span-2 mt-4">
-    <h2 class="text-xl font-bold">Mecánica</h2>
-  </div>
-
-  <!-- Transmisión y motor original select -->
-  <div>
-    <label for="originalTransmissionEngine" class="block mb-1 text-sm">¿Transmisión y motor original? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="originalTransmissionEngine" formControlName="originalTransmissionEngine" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('originalTransmissionEngine')) {
-    <shared-input-error [message]="getError('originalTransmissionEngine')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Mejora o modificación general select -->
-  <div>
-    <label for="improvementModificationOriginal" class="block mb-1 text-sm">¿Mejora o modificación general? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="improvementModificationOriginal" formControlName="improvementModificationOriginal" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('improvementModificationOriginal')) {
-    <shared-input-error [message]="getError('improvementModificationOriginal')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Servicios realizados con fechas textarea -->
-  <div class="col-span-2">
-    <label for="performedServicesWithDates" class="block mb-1 text-sm">Servicios realizados con fechas</label>
-    <textarea id="performedServicesWithDates" formControlName="performedServicesWithDates" rows="4" sharedInput
-      sharedAutoResizeTextarea></textarea>
-    @if (hasError('performedServicesWithDates')) {
-    <shared-input-error [message]="getError('performedServicesWithDates')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Problema o detalle mecánico select -->
-  <div>
-    <label for="mechanicalProblemDetail" class="block mb-1 text-sm">¿Problema o detalle mecánico? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="mechanicalProblemDetail" formControlName="mechanicalProblemDetail" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('mechanicalProblemDetail')) {
-    <shared-input-error [message]="getError('mechanicalProblemDetail')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Sensor iluminado en el tablero select -->
-  <div>
-    <label for="illuminatedDashboardSensor" class="block mb-1 text-sm">¿Sensor iluminado en el tablero? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="illuminatedDashboardSensor" formControlName="illuminatedDashboardSensor" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('illuminatedDashboardSensor')) {
-    <shared-input-error [message]="getError('illuminatedDashboardSensor')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Equipamiento de fabrica select -->
-  <div>
-    <label for="factoryEquipment" class="block mb-1 text-sm">¿Equipamiento de fabrica? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="factoryEquipment" formControlName="factoryEquipment" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('factoryEquipment')) {
-    <shared-input-error [message]="getError('factoryEquipment')"></shared-input-error>
-    }
-  </div>
-
-  <!-- Equipamiento extra select -->
-  <div>
-    <label for="extraEquipment" class="block mb-1 text-sm">¿Equipamiento extra? <span
-        class="font-bold text-red-500 inline-block">*</span></label>
-    <select id="extraEquipment" formControlName="extraEquipment" sharedInput>
-      <option value="true">Sí</option>
-      <option value="false">No</option>
-    </select>
-
-    @if (hasError('extraEquipment')) {
-    <shared-input-error [message]="getError('extraEquipment')"></shared-input-error>
     }
   </div>
 
@@ -232,5 +82,4 @@
       Siguiente
       }
     </button>
-  </div>
-</form>
+  </div></form>

--- a/src/app/register-car/components/mechanics/mechanics.component.ts
+++ b/src/app/register-car/components/mechanics/mechanics.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild, WritableSignal, effect, inject, signal, viewChild } from '@angular/core';
-import { FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, ElementRef, WritableSignal, effect, inject, signal, viewChild } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Uppy } from '@uppy/core';
 import { UppyAngularDashboardModule } from '@uppy/angular';
 import Dashboard from '@uppy/dashboard';
@@ -174,35 +174,13 @@ export class MechanicsComponent {
 
   constructor() {
     this.mechanicsForm = this.#fb.group({
-      originalRims: ['', [Validators.required]],
-      // rimsDetail: ['', [Validators.required]],
       tireBrand: [''],
       tireSize: [''],
-      tireDate: [''],
-      tireCondition: ['', [Validators.required]],
-      extraTiresOrRims: ['', [Validators.required]],
-      // extraBrand: ['', [Validators.required]],
-      // extraColor: ['', [Validators.required]],
-      // extraSize: ['', [Validators.required]],
       spareTire: ['', [Validators.required]],
-      originalTransmissionEngine: ['', [Validators.required]],
-      improvementModificationOriginal: ['', [Validators.required]],
-      // whatImprovement: ['', [Validators.required]],
-      performedServicesWithDates: [''],
-      mechanicalProblemDetail: ['', [Validators.required]],
-      // whatMechanicalProblem: ['', [Validators.required]],
-      illuminatedDashboardSensor: ['', [Validators.required]],
-      // whichIlluminatedSensor: ['', [Validators.required]],
-      factoryEquipment: ['', [Validators.required]],
-      extraEquipment: ['', [Validators.required]],
-      // whatExtraEquipment: ['', [Validators.required]],
       comments: ['', [Validators.required]],
       mechanicsPhotos: [[], [Validators.required]],
       mechanicsVideos: [[]],
       originalAuctionCarId: [this.originalAuctionCarId, [Validators.required]],
-      // dashboardWarningLight: ['', [Validators.required]],
-      // servicesDoneWithDates: ['', [Validators.required]],
-      // improvementOrModification: ['', [Validators.required]],
     });
 
     this.batchTokenDirect();
@@ -251,20 +229,9 @@ export class MechanicsComponent {
     this.#completeCarRegistrationService.getMechanics$(this.originalAuctionCarId).subscribe({
       next: (mechanics) => {
         let {
-          originalRims,
           tireBrand,
           tireSize,
-          tireDate,
-          tireCondition,
-          extraTiresOrRims,
           spareTire,
-          originalTransmissionEngine,
-          improvementModificationOriginal,
-          performedServicesWithDates,
-          mechanicalProblemDetail,
-          illuminatedDashboardSensor,
-          factoryEquipment,
-          extraEquipment,
           comments,
           mechanicsPhotos,
           mechanicsVideos,
@@ -278,40 +245,18 @@ export class MechanicsComponent {
         ];
 
         if (this.user && emails.includes(this.user.attributes.email)) {
-          //Sobreescribir con valores de prueba
-          originalRims = true;
+          // Sobreescribir con valores de prueba
           tireBrand = 'Michelin';
           tireSize = '205/55 R16';
-          tireDate = '2021-08-01';
-          tireCondition = 'Excelente';
-          extraTiresOrRims = 'false';
           spareTire = true;
-          originalTransmissionEngine = true;
-          improvementModificationOriginal = true;
-          performedServicesWithDates = 'Cambio de aceite 2021-08-01';
-          mechanicalProblemDetail = false;
-          illuminatedDashboardSensor = true;
-          factoryEquipment = false;
-          extraEquipment = false;
           comments = 'Comentarios de prueba';
           // mechanicsPhotos = (mechanicsPhotos && mechanicsPhotos.length > 0) ? mechanicsPhotos : ['https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/79c2c836-05b7-4063-de6f-1a8e105eaa00/public', 'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/27c09383-2145-475d-4992-7b7ecc191200/public'];
         }
 
         this.mechanicsForm.patchValue({
-          originalRims,
           tireBrand,
           tireSize,
-          tireDate,
-          tireCondition,
-          extraTiresOrRims,
           spareTire,
-          originalTransmissionEngine,
-          improvementModificationOriginal,
-          performedServicesWithDates,
-          mechanicalProblemDetail,
-          illuminatedDashboardSensor,
-          factoryEquipment,
-          extraEquipment,
           comments,
           mechanicsPhotos,
           mechanicsVideos,

--- a/src/app/register-car/services/complete-car-registration.service.ts
+++ b/src/app/register-car/services/complete-car-registration.service.ts
@@ -81,7 +81,25 @@ export class CompleteCarRegistrationService {
   }
 
   saveMechanics$(mechanics: FormGroup): Observable<any> {
-    const trimmedMechanics = this.#appService.trimObjectValues(mechanics.value);
+    const {
+      tireBrand,
+      tireSize,
+      spareTire,
+      comments,
+      mechanicsPhotos,
+      mechanicsVideos,
+      originalAuctionCarId,
+    } = mechanics.value;
+
+    const trimmedMechanics = this.#appService.trimObjectValues({
+      tireBrand,
+      tireSize,
+      spareTire,
+      comments,
+      mechanicsPhotos,
+      mechanicsVideos,
+      originalAuctionCarId,
+    });
 
     const url = `${this.#baseUrl}/mechanics-detail-cars`;
 


### PR DESCRIPTION
## Summary
- trim mechanics form to only keep required fields
- narrow POST payload for register car mechanics details
- narrow PUT payload for updating mechanics details

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eb42f2e048320b55128d7e8af66d1