### PR TITLE
Remove required interior photos

### DIFF
--- a/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.html
+++ b/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.html
@@ -41,7 +41,7 @@
   <div class="col-span-2">
     <label id="uppyDashboardImages" for="interiorImages" class="text-sm cursor-pointer">
       Fotos del interior del auto
-      <span class="font-bold text-red-500 inline-block">*</span></label>
+    </label>
 
     <p class="mb-2 text-sm">Se recomienda subir fotos con orientación horizontal</p>
 

--- a/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
+++ b/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
@@ -176,7 +176,7 @@ export class InteriorOfTheCarComponent {
       interiorColor: [{ value: '', disabled: true }, [Validators.required]],
       material: ['', [Validators.required]],
       interiorDetails: ['', [Validators.required]],
-      interiorPhotos: [[], [Validators.required]],
+      interiorPhotos: [[]],
       interiorVideos: [[]],
       originalAuctionCarId: [this.originalAuctionCarId, [Validators.required]],
     });
@@ -259,8 +259,22 @@ export class InteriorOfTheCarComponent {
           interiorColor = interiorColor || 'Black';
           material = material || 'Leather';
           interiorDetails = interiorDetails || 'No comments';
-          // interiorPhotos = (interiorPhotos && interiorPhotos.length > 0) ? interiorPhotos : ['https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/79c2c836-05b7-4063-de6f-1a8e105eaa00/public', 'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/27c09383-2145-475d-4992-7b7ecc191200/public'];
-          interiorVideos = interiorVideos || [];
+          interiorPhotos =
+            interiorPhotos && interiorPhotos.length > 0
+              ? interiorPhotos
+              : [
+                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/79c2c836-05b7-4063-de6f-1a8e105eaa00/public',
+                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/27c09383-2145-475d-4992-7b7ecc191200/public',
+                ];
+          interiorVideos =
+            interiorVideos && interiorVideos.length > 0
+              ? interiorVideos
+              : [
+                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/8e340451-9379-474c-85e4-2b0d2c0c3a00/public',
+                ];
+
+          this.interiorPhotos.clearValidators();
+          this.interiorPhotos.updateValueAndValidity();
         }
 
         this.interiorOfTheCarForm.patchValue({


### PR DESCRIPTION
## Summary
- remove mandatory indicator on interior photos
- use default interior images/videos during testing
- make interior photos optional

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eb4b065fc83208ecf7338e6c6b16f