### PR TITLE
Remove demo media URLs from auction services

### DIFF
--- a/src/app/art/services/register-art.service.ts
+++ b/src/app/art/services/register-art.service.ts
@@ -19,14 +19,6 @@ export class RegisterArtService {
 
     trimmedFormGroup.reserve = trimmedFormGroup.reserve === 'true';
 
-    trimmedFormGroup.photos = [
-      'http://res.cloudinary.com/demo/image/upload/v1/exterior1.jpg',
-      'http://res.cloudinary.com/demo/image/upload/v1/exterior2.jpg'
-    ];
-    trimmedFormGroup.videos = [
-      'http://res.cloudinary.com/demo/image/upload/v1/exterior1.jpg'
-    ];
-
     const url = `${this.#baseUrl}/auction-items/register-art`;
 
     return this.#http.post<any>(url, trimmedFormGroup);

--- a/src/app/register-car/services/register-car.service.ts
+++ b/src/app/register-car/services/register-car.service.ts
@@ -21,14 +21,6 @@ export class RegisterCarService {
 
     trimmedRegisterCar.reserve = trimmedRegisterCar.reserve === 'true';
 
-    trimmedRegisterCar.photos = [
-      'http://res.cloudinary.com/demo/image/upload/v1/exterior1.jpg',
-      'http://res.cloudinary.com/demo/image/upload/v1/exterior2.jpg'
-    ];
-    trimmedRegisterCar.videos = [
-      'http://res.cloudinary.com/demo/image/upload/v1/exterior1.jpg'
-    ];
-
     const token = localStorage.getItem('token');
 
     if (!token) throw new Error('No token found');


### PR DESCRIPTION
## Summary
- clean up `register-car.service` and `register-art.service`
- avoid sending demo photo/video URLs when registering auctions

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686edca667848320995da6348e7fedf8