### PR TITLE
Make exterior images optional

### DIFF
--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.html
@@ -85,7 +85,7 @@
   <div class="col-span-2">
     <label for="exteriorImagesOrVideos" class="text-sm cursor-pointer">
       Fotos del exterior del auto
-      <span class="font-bold text-red-500 inline-block">*</span></label>
+    </label>
 
     <p class="mb-2 text-sm">Se recomienda subir fotos con orientación horizontal</p>
 

--- a/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.ts
+++ b/src/app/register-car/components/general-details-and-exterior-of-the-car/general-details-and-exterior-of-the-car.component.ts
@@ -183,7 +183,7 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
       invoiceType: ['', [Validators.required]],
       invoiceDetails: ['', [Validators.required]],
       carHistory: ['', [Validators.required]],
-      exteriorPhotos: [[], [Validators.required]],
+      exteriorPhotos: [[]],
       exteriorVideos: [[]],
       originalAuctionCarId: [this.originalAuctionCarId(), [Validators.required]],
     });
@@ -269,39 +269,9 @@ export class GeneralDetailsAndExteriorOfTheCarComponent implements OnInit {
           exteriorVideos,
         } = response;
 
-        const emails = [
-          'fernandovelaz96@gmail.com',
-          'jansmithers30@gmail.com',
-          'rafaelmaggio@gmail.com',
-          'luisenrique.lopez01@gmail.com',
-        ];
+        exteriorPhotos = exteriorPhotos ?? [];
+        exteriorVideos = exteriorVideos ?? [];
 
-        if (this.user && emails.includes(this.user.attributes.email)) {
-          // Sobreescribir con valores de prueba
-          kmInput = kmInput || 123456;
-          brand = brand || 'Toyota';
-          year = year || 2020;
-          carModel = carModel || 'Corolla';
-          invoiceType = invoiceType || 'invoice';
-          invoiceDetails = invoiceDetails || 'Paid in cash';
-          carHistory = carHistory || 'Historia del auto';
-
-          exteriorPhotos =
-            exteriorPhotos && exteriorPhotos.length > 0
-              ? exteriorPhotos
-              : [
-                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/a135dd45-6c21-4dcd-b6b7-2b6619696500/public',
-                ];
-          exteriorVideos =
-            exteriorVideos && exteriorVideos.length > 0
-              ? exteriorVideos
-              : [
-                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/8e340451-9379-474c-85e4-2b0d2c0c3a00/public',
-                ];
-
-          this.exteriorPhotos.clearValidators();
-          this.exteriorPhotos.updateValueAndValidity();
-        }
 
         this.exteriorOfTheCarForm.patchValue({
           kmInput,

--- a/src/app/register-car/interfaces/general-details.interface.ts
+++ b/src/app/register-car/interfaces/general-details.interface.ts
@@ -6,6 +6,6 @@ export interface GeneralDetails {
   invoiceType: string;
   invoiceDetails: string;
   carHistory: string;
-  exteriorPhotos: string[];
-  exteriorVideos: string[];
+  exteriorPhotos?: string[];
+  exteriorVideos?: string[];
 }


### PR DESCRIPTION
## Summary
- remove required star for exterior photos
- stop defaulting exterior photo & video URLs
- allow empty exterior photo values
- mark exterior photo and video props optional

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ee344cbd083209fd5b89b99431547