### PR TITLE
Make interior photos and videos optional

### DIFF
--- a/src/app/auctions/interfaces/auction-details.ts
+++ b/src/app/auctions/interfaces/auction-details.ts
@@ -175,8 +175,8 @@ export interface AuctionDetailsInteriorDetails {
   interiorColor: string;
   material: string;
   interiorDetails: string;
-  interiorPhotos: string[];
-  interiorVideos: any[];
+  interiorPhotos?: string[];
+  interiorVideos?: any[];
 }
 
 export interface AuctionDetailsMechanicsDetails {

--- a/src/app/dashboard/interfaces/wizard-data.ts
+++ b/src/app/dashboard/interfaces/wizard-data.ts
@@ -69,8 +69,8 @@ export interface WizardDataInteriorDetails {
   interiorColor: string;
   material: string;
   interiorDetails: string;
-  interiorPhotos: string[];
-  interiorVideos: any[];
+  interiorPhotos?: string[];
+  interiorVideos?: any[];
 }
 
 export interface WizardDataMechanicsDetails {

--- a/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
+++ b/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
@@ -247,35 +247,6 @@ export class InteriorOfTheCarComponent {
           interiorVideos,
         } = interiorOfTheCar;
 
-        const emails = [
-          'fernandovelaz96@gmail.com',
-          'jansmithers30@gmail.com',
-          'rafaelmaggio@gmail.com',
-          'luisenrique.lopez01@gmail.com',
-        ];
-
-        if (this.user && emails.includes(this.user.attributes.email)) {
-          //Sobreescribir con valores de prueba
-          interiorColor = interiorColor || 'Black';
-          material = material || 'Leather';
-          interiorDetails = interiorDetails || 'No comments';
-          interiorPhotos =
-            interiorPhotos && interiorPhotos.length > 0
-              ? interiorPhotos
-              : [
-                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/79c2c836-05b7-4063-de6f-1a8e105eaa00/public',
-                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/27c09383-2145-475d-4992-7b7ecc191200/public',
-                ];
-          interiorVideos =
-            interiorVideos && interiorVideos.length > 0
-              ? interiorVideos
-              : [
-                  'https://imagedelivery.net/0QBC7WyyrF76Zf9i8s__Sg/8e340451-9379-474c-85e4-2b0d2c0c3a00/public',
-                ];
-
-          this.interiorPhotos.clearValidators();
-          this.interiorPhotos.updateValueAndValidity();
-        }
 
         this.interiorOfTheCarForm.patchValue({
           interiorColor,

--- a/src/app/register-car/interfaces/interior-of-the-car.interface.ts
+++ b/src/app/register-car/interfaces/interior-of-the-car.interface.ts
@@ -2,7 +2,7 @@ export interface InteriorOfTheCar {
   interiorColor: string;
   material: string;
   interiorDetails: string;
-  interiorPhotos: string[];
-  interiorVideos: string[];
+  interiorPhotos?: string[];
+  interiorVideos?: string[];
   originalAuctionCarId: string;
 }


### PR DESCRIPTION
## Summary
- remove default photo and video URLs from interior form
- mark `interiorPhotos` and `interiorVideos` as optional
- update related interfaces

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ee4f5ce088320a33e59a21f6dbdc6