### PR TITLE
Fix disabled interior color input

### DIFF
--- a/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
+++ b/src/app/register-car/components/interior-of-the-car/interior-of-the-car.component.ts
@@ -173,7 +173,7 @@ export class InteriorOfTheCarComponent {
 
   constructor() {
     this.interiorOfTheCarForm = this.#fb.group({
-      interiorColor: [{ value: '', disabled: true }, [Validators.required]],
+      interiorColor: ['', [Validators.required]],
       material: ['', [Validators.required]],
       interiorDetails: ['', [Validators.required]],
       interiorPhotos: [[]],


### PR DESCRIPTION
## Summary
- allow editing the interior color while registering a car

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ee6cb6c1083208a5436da4b3045e5