### PR TITLE
Fix identity image defaults

### DIFF
--- a/src/app/auth/pages/complete-register/complete-register.component.ts
+++ b/src/app/auth/pages/complete-register/complete-register.component.ts
@@ -16,9 +16,6 @@ import { CloudinaryCroppedImageService } from '@app/dashboard/services/cloudinar
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { JsonPipe } from '@angular/common';
 
-const DEFAULT_INE_FRONT_IMAGE_URL = 'https://placehold.co/600x400?text=INE+Frontal';
-const DEFAULT_INE_BACK_IMAGE_URL = 'https://placehold.co/600x400?text=INE+Posterior';
-
 @Component({
   selector: 'complete-register',
   standalone: true,
@@ -66,8 +63,8 @@ export class CompleteRegisterComponent implements OnInit, OnDestroy {
       postalCode: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(5)]],
       validationType: [idTypes.ine, [Validators.required]],
       validationImg: this.#fb.array([
-        [DEFAULT_INE_FRONT_IMAGE_URL, [Validators.required]],
-        [DEFAULT_INE_BACK_IMAGE_URL, [Validators.required]]
+        ['', [Validators.required]],
+        ['', [Validators.required]]
       ]),
     });
 
@@ -153,8 +150,8 @@ export class CompleteRegisterComponent implements OnInit, OnDestroy {
     switch (type) {
       case idTypes.ine:
         this.completeRegisterForm?.setControl('validationImg', new FormArray([
-          new FormControl(DEFAULT_INE_FRONT_IMAGE_URL, Validators.required),
-          new FormControl(DEFAULT_INE_BACK_IMAGE_URL, Validators.required),
+          new FormControl('', Validators.required),
+          new FormControl('', Validators.required),
         ]));
 
         break;


### PR DESCRIPTION
## Summary
- remove hardcoded INE placeholder URLs
- initialise `validationImg` with empty values so users can upload images

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686eeb37a0bc8320b2a15671bf3e4d4f